### PR TITLE
Corrected minor issue in the column names of the PTMS exported table.

### DIFF
--- a/src/pypath/main.py
+++ b/src/pypath/main.py
@@ -3633,7 +3633,7 @@ class PyPath(object):
         if 'ptm' not in g.es.attributes():
             g.es['ptm'] = [[] for _ in g.es]
         header = [
-            'UniProt_A', 'UniProt_B', 'GeneSymbol_B', 'GeneSymbol_A',
+            'UniProt_A', 'UniProt_B', 'GeneSymbol_A', 'GeneSymbol_B',
             'Databases', 'PubMed_IDs', 'Stimulation', 'Inhibition',
             'Substrate-isoform', 'Residue_number', 'Residue_letter', 'PTM_type'
         ]


### PR DESCRIPTION
Column names in the table exported by `export_ptms_tab` did not match the entries in the table. `GeneSymbol_B` and `GeneSymbol_A` seemed to be mixed up.
Example output:
```
UniProt_A	UniProt_B	GeneSymbol_B	GeneSymbol_A	Databases	Stimulation	Inhibition	Substrate-isoform	Residue_number	Residue_letter	PTM_type
P31749	P18031	AKT1	PTPN1	MIMP;Signor;dbPTM;PhosphoSite;SignaLink3;HPRD	0	1	P18031-1	50	S	phosphorylation
P31749	P12755	AKT1	SKI	MIMP;Signor;PhosphoSite	0	1	P12755-1	458	T	phosphorylation
Q13882	P31749	PTK6	AKT1	MIMP;PhosphoSite;Signor	1	0	P31749-1	315	Y	phosphorylation
Q13882	P31749	PTK6	AKT1	MIMP;PhosphoSite;Signor	1	0	P31749-1	326	Y	phosphorylation

```