### PR TITLE
Fix: go.py could not import progress.py

### DIFF
--- a/src/pypath/go.py
+++ b/src/pypath/go.py
@@ -20,7 +20,7 @@ from collections import Counter, OrderedDict
 
 # from this package:
 from pypath import dataio
-import pypath.progress
+from pypath import progress
 from pypath import enrich
 from pypath.common import *
 


### PR DESCRIPTION
Tried to run `pa.load_go()` but raised an error. Now seems to be working.