### PR TITLE
Fixed bug on PyPath.vsup()

### DIFF
--- a/src/pypath/main.py
+++ b/src/pypath/main.py
@@ -1595,7 +1595,7 @@ class PyPath(object):
         return _NamedVertexSeq(self.graph.vs, self.nodNam, self.nodLab).gs()
 
     def vsup(self):
-        return _NamedVertexSeq(self.graph.vs, self.nodNam, self.nodLab).gs()
+        return _NamedVertexSeq(self.graph.vs, self.nodNam, self.nodLab).up()
 
     def update_vindex(self):
         """


### PR DESCRIPTION
It was returning the GeneSymbol and not UniProt IDs