### PR TITLE
PyPath.sorensen_pathways()

### DIFF
--- a/src/pypath/main.py
+++ b/src/pypath/main.py
@@ -4425,8 +4425,8 @@ class PyPath(object):
 
                 edges[pw].append(e.index)
 
-        sNodes = self.sorensen_groups(nodes)
-        sEdges = self.sorensen_groups(edges)
+        sNodes = self.similarity_groups(nodes, index='sorensen')
+        sEdges = self.similarity_groups(edges, index='sorensen')
 
         return {"nodes": sNodes, "edges": sEdges}
 


### PR DESCRIPTION
The function `PyPath.sorensen_pathways()` calls another function named `PyPath.sorensen_groups()` which is not defined in the class (or nowhere else in the package). I assume the aim was to do the same as `PyPath.similarity_groups(index='sorensen')`?