### PR TITLE
update_pathway and update_pathway_types

### DIFF
--- a/src/pypath/main.py
+++ b/src/pypath/main.py
@@ -5299,9 +5299,13 @@ class PyPath(object):
                 #    sys.stdout.flush()
 
         sys.stdout.write('\n')
+
         self.clean_graph()
         self.update_sources()
         self.update_vertex_sources()
+        self.update_pathways()
+        self.update_pathway_types()
+
         sys.stdout.write(
             """\n > %u interactions between %u nodes\n from %u"""
             """ resources have been loaded,\n for details see the log: ./%s\n"""


### PR DESCRIPTION
On previous pull requests, I added the `update_pathways()` and `update_pathway types()` whenever `load_pathways()` was called (which applies for KEGG and Signor). Thing is, from `init_network()`, 'slk_pathways' is loaded automatically, so I also added the update functions after `load_resources()`.