### PR TITLE
Fix PyPath.having_attr()

### DIFF
--- a/src/pypath/main.py
+++ b/src/pypath/main.py
@@ -5471,7 +5471,7 @@ class PyPath(object):
 
             for i in es_or_vs:
 
-                if something(i[attr]):
+                if common.something(i[attr]):
                     yield i.index if index else i
 
     def having_eattr(self, attr, graph=None, index=True):


### PR DESCRIPTION
Method calls function `something` defined in `common` which is imported as `import pypath.common as common`, not as `from pypath.common import *` so it was raising `NameError` .