### PR TITLE
Fixed PyPath.apply_negative

### DIFF
--- a/src/pypath/main.py
+++ b/src/pypath/main.py
@@ -5664,7 +5664,7 @@ class PyPath(object):
                         list(
                             map(lambda r: _refs.Reference(int(r)), n[
                                 'attrsEdge']['references'])))
-                    g.es[edge]['negative_refs'].add(refs)
+                    g.es[edge]['negative_refs'].update(refs)
                     matches += 1
 
             prg.step()


### PR DESCRIPTION
Loading Negatome raises `TypeError: unhashable type: 'set'`. Problem was that when updating the `'negative_references'` attribute on the edges (which is a set) with `refs` (another set), the `set.add` function was called (adds single element) instead of `set.update` (merges sets).