### PR TITLE
Update BEL converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.egg-info/
 cache/
 log/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 cache/
 log/
 .idea
+pip-wheel-metadata/*

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ setup(
         'bel': [
             'pybel',
             'bio2bel',
+            'click',
         ],
     },
     entry_points=ENTRY_POINTS,

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,14 @@ with open('README.rst') as f:
 with open('HISTORY.rst') as f:
     history = f.read()
 
+ENTRY_POINTS = {
+    'console_scripts': [
+        'bio2bel_omnipath = pypath.bel:main',
+    ],
+    'bio2bel': [
+        'omnipath = pypath.bel',
+    ],
+}
 
 setup(
     name = 'pypath',
@@ -105,6 +113,8 @@ setup(
         ],
         'bel': [
             'pybel',
+            'bio2bel',
         ],
-    }
+    },
+    entry_points=ENTRY_POINTS,
 )

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,9 @@ setup(
         ],
         'docs': [
             'sphinx',
-        ]
+        ],
+        'bel': [
+            'pybel',
+        ],
     }
 )

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -1,25 +1,22 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Convert OmniPath components to PyBEL."""
+"""Convert OmniPath components to PyBEL.
 
-#
-#  This file is part of the `pypath` python module
-#
-#  Copyright
-#  2014-2019
-#  EMBL, EMBL-EBI, Uniklinik RWTH Aachen, Heidelberg University
-#
-#  File author(s): Dénes Türei (turei.denes@gmail.com)
-#                  Nicolàs Palacio
-#
-#  Distributed under the GPLv3 License.
-#  See accompanying file LICENSE.txt or copy at
-#      http://www.gnu.org/licenses/gpl-3.0.html
-#
-#  Website: http://pypath.omnipathdb.org/
-#
+This file is part of the `pypath` python module
 
+Copyright
+2014-2019
+EMBL, EMBL-EBI, Uniklinik RWTH Aachen, Heidelberg University
+
+File author(s): Dénes Türei (turei.denes@gmail.com)
+                 Nicolàs Palacio
+
+Distributed under the GPLv3 License.
+See accompanying file LICENSE.txt or copy at
+     http://www.gnu.org/licenses/gpl-3.0.html
+
+Website: http://pypath.omnipathdb.org/
+"""
 
 import itertools as itt
 import sys

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -24,9 +24,6 @@ from typing import Set
 
 from tqdm import tqdm
 
-import pybel.constants as pc
-from pybel.dsl import Protein
-
 try:
     import pybel
 
@@ -49,8 +46,14 @@ except ModuleNotFoundError:
     )
     pybel = None
 
+import pybel.constants as pc
 from bio2bel.manager.bel_manager import BELManagerMixin
 from bio2bel.manager.cli_manager import CliMixin
+
+__all__ = [
+    'Bel',
+    'main',
+]
 
 
 class Bel(BELManagerMixin, CliMixin):
@@ -216,8 +219,8 @@ class Bel(BELManagerMixin, CliMixin):
         )
 
     @staticmethod
-    def _protein(identifier, id_type='uniprot') -> Protein:
-        return Protein(namespace=id_type.upper(), name=identifier)
+    def _protein(identifier, id_type='uniprot') -> pybel.dsl.Protein:
+        return pybel.dsl.Protein(namespace=id_type.upper(), name=identifier)
 
     def resource_to_relationships_enzyme_substrate(self, enz_sub):
         pass
@@ -249,11 +252,12 @@ class Bel(BELManagerMixin, CliMixin):
         path : str
             Path to the output file.
         """
-        pybel.to_bel_path(self.bel_graph, path, **kwargs)
+        pybel.to_bel_path(self.to_bel(), path, **kwargs)
 
     def to_bel_json(self, path: str, **kwargs):
         """Export the BEL model as a node-link JSON file."""
-        pybel.to_json_path(self.bel_graph, path, **kwargs)
+        pybel.to_json_path(self.to_bel(), path, **kwargs)
+
 
 main = Bel.get_cli()
 

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -18,41 +18,40 @@
 #  Website: http://pypath.omnipathdb.org/
 #
 
-from future.utils import iteritems
-from past.builtins import xrange, range
 
-
-import sys
-import imp
 import collections
+import imp
+import itertools as itt
+import sys
+from typing import Set
 
+import pybel.constants as pc
+from pybel.dsl import Protein
 
 try:
-    
+
     import pybel
-    
+
     if hasattr(pybel, 'ob'):
-        
         sys.stdout.write(
             'pypath.bel: You have the `openbabel` module installed '
             'instead of `pybel`.\n'
             'To be able to use `pybel`, create a virtual env and install '
             'it by `pip install pybel`.\n'
         )
-        
+
         # unimport openbabel
         del sys.modules['pybel']
         pybel = None
-    
+
 except ModuleNotFoundError:
-    
+
     sys.stdout.write(
         'pypath.bel: module `pybel` not available.\n'
         'You won\'t be able to read or write BEL models.\n'
     )
-    
-    pybel = None
 
+    pybel = None
 
 Relationship = collections.namedtuple(
     'Relationship',
@@ -82,235 +81,154 @@ class Bel(object):
     >>> pa.init_network(data_formats.pathway)
     >>> be = bel.Bel(resource = pa)
     >>> be.resource_to_relationships()
-    >>> be.relationships_to_bel()
     >>> be.export_bel(fname = 'omnipath_pathways.bel')
     """
-    
+
     def __init__(
             self,
             resource,
-            only_sources = None,
-        ):
-        
-        self.relationships = []
-        self.bel = None
+            only_sources=None,
+    ):
+        self.bel_graph: pybel.BELGraph = pybel.BELGraph()
         self.resource = resource
         self.only_sources = only_sources
-    
-    
+
     def reload(self):
-        
         modname = self.__class__.__module__
-        mod = __import__(modname, fromlist = [modname.split('.')[0]])
+        mod = __import__(modname, fromlist=[modname.split('.')[0]])
         imp.reload(mod)
         new = getattr(mod, self.__class__.__name__)
         setattr(self, '__class__', new)
-    
-    
+
     def main(self):
-        
-        self.resource_to_relationships()
-        self.relationships_to_bel()
-    
-    
-    def resource_to_relationships(self):
-        """
-        Converts the resource object to list of BEL relationships.
-        """
-        
+        """Convert the resource object to list of BEL relationships."""
         if hasattr(self.resource, 'graph'):
             # PyPath object
-            
             self.resource_to_relationships_graph()
-            
+
         elif hasattr(self.resource, 'enz_sub'):
             # PtmAggregator object
-            
             self.resource_to_relationships_enzyme_substrate()
-            
+
         elif hasattr(self.resource, 'complexes'):
             # ComplexAggregator object
-            
             self.resource_to_relationships_complex()
-            
+
         elif hasattr(self.resource, 'network'):
             # NetworkResource object
-            
             self.resource_to_relationships_network()
-    
-    
+
     def resource_to_relationships_graph(self):
-        """
-        Converts a PyPath igraph object into list of BEL relationships.
-        """
-        
+        """Convert a PyPath igraph object into list of BEL relationships."""
         for edge in self.resource.graph.es:
-            
             directions = edge['dirs']
-            
+
             for direction in (directions.straight, directions.reverse):
-                
                 if not directions.dirs[direction]:
                     # this direction does not exist
-                    
                     continue
-                
-                dir_sources = directions.get_dir(direction, sources = True)
-                
+
+                dir_sources = directions.get_dir(direction, sources=True)
+
                 if self.only_sources and not dir_sources & self.only_sources:
                     # this direction not provided
                     # in the currently enabled set of sources
-                    
                     continue
-                
+
                 predicates = set()
-                
+
                 activation, inhibition = (
-                    directions.get_sign(direction, sources = True)
+                    directions.get_sign(direction, sources=True)
                 )
-                
+
                 if self._check_sign(activation):
-                    
-                    predicates.add('directlyIncreases')
-                
+                    predicates.add(pc.DIRECTLY_INCREASES)
+
                 if self._check_sign(inhibition):
-                    
-                    predicates.add('directlyDecreases')
-                
+                    predicates.add(pc.DIRECTLY_DECREASES)
+
                 if not predicates:
                     # use `regulates` if sign is unknown
-                    
-                    predicates.add('regulates')
-                
-                references = self._references(edge, direction)
-                
-                for predicate in predicates:
-                    
-                    rel = Relationship(
-                        subject    = self._protein(direction[0]),
-                        predicate  = predicate,
-                        object     = self._protein(direction[1]),
-                        references = references,
+                    predicates.add(pc.REGULATES)
+
+                source = self._protein(direction[0])
+                target = self._protein(direction[1])
+                citations = self._references(edge, direction)
+
+                for predicate, citation in itt.product(predicates, citations):
+                    self.bel_graph.add_qualified_edge(
+                        source, target,
+                        relation=predicate,
+                        citation=citation,
+                        evidence='From OmniPath',
                     )
-                    
-                    self.relationships.append(rel)
-        
+
         if not self._has_direction(directions):
             # add an undirected relationship
             # if no direction available
-            
-            references = self._references(edge, 'undirected')
-            
-            rel = Relationship(
-                subject    = self._protein(directions.nodes[0]),
-                predicate  = 'association',
-                object     = self._protein(directions.nodes[1]),
-                references = references,
-            )
-            
-            self.relationships.append(rel)
-    
-    
-    def _references(self, edge, direction):
-        
+
+            citations = self._references(edge, 'undirected')
+            source = self._protein(directions.nodes[0])
+            target = self._protein(directions.nodes[1])
+
+            for citation in citations:
+                self.bel_graph.add_qualified_edge(
+                    source, target,
+                    relation='association',
+                    citation=citation,
+                    evidence='From OmniPath',
+                )
+
+    def _references(self, edge, direction) -> Set[str]:
         by_dir = edge['refs_by_dir']
         references = by_dir[direction] if direction in by_dir else set()
-        
+
         if self.only_sources:
-            
             references = (
-                references &
-                set.union(
-                    *(
-                        edge['refs_by_source'][src]
-                        for src in (self.only_sources & edge['sources'])
+                    references &
+                    set.union(
+                        *(
+                            edge['refs_by_source'][src]
+                            for src in (self.only_sources & edge['sources'])
+                        )
                     )
-                )
             )
-        
-        references = set(ref.pmid for ref in references)
-        
-        return references
-    
-    
+
+        return {str(ref.pmid) for ref in references}
+
     def _check_sign(self, this_sign_sources):
-        
         return (
-            this_sign_sources and
-            (
-                not self.only_sources or
-                this_sign_sources & self.only_sources
-            )
-        )
-    
-    
-    def _has_direction(self, directions):
-        
-        if not self.only_sources:
-            
-            return directions.is_directed()
-            
-        else:
-            
-            return (
+                this_sign_sources and
                 (
-                    directions.sources_straight() |
-                    directions.sources_reverse()
-                ) &
-                self.only_sources
-            )
-    
-    
+                        not self.only_sources or
+                        this_sign_sources & self.only_sources
+                )
+        )
+
+    def _has_direction(self, directions):
+        if not self.only_sources:
+            return directions.is_directed()
+
+        return (
+                (
+                        directions.sources_straight() |
+                        directions.sources_reverse()
+                ) & self.only_sources
+        )
+
     @staticmethod
-    def _protein(identifier, id_type = 'uniprot'):
-        
-        return 'p(%s:%s)' % (id_type.upper(), identifier)
-    
-    
+    def _protein(identifier, id_type='uniprot') -> Protein:
+        return Protein(namespace=id_type.upper(), name=identifier)
+
     def resource_to_relationships_enzyme_substrate(self):
-        
         pass
-    
-    
+
     def resource_to_relationships_complex(self):
-        
         raise NotImplementedError
-    
-    
+
     def resource_to_relationships_network(self):
-        
         raise NotImplementedError
-    
-    
-    def relationships_to_bel(self):
-        """
-        Converts the relationships into a ``pybel.BELGraph`` object.
-        """
-        
-        self.bel = pybel.BELGraph()
-        bel_parser = pybel.parser.BELParser(self.bel)
-        
-        for rel in self.relationships:
-            
-            for pubmed in rel.references or ('0',):
-                
-                bel_parser.control_parser.clear()
-                bel_parser.citation = {
-                    pybel.constants.CITATION_REFERENCE: pubmed,
-                    pybel.constants.CITATION_TYPE:
-                        pybel.constants.CITATION_TYPE_PUBMED,
-                }
-                #TODO: what to add here?
-                bel_parser.control_parser.evidence = 'PubMed:%s' % pubmed
-                
-                
-                bel_string = ' '.join(rel[:3])
-                print(bel_string)
-                bel_parser.control_parser.parseString(bel_string)
-        
-        #TODO: add other types of objects to this graph
-    
-    
+
     def export_relationships(self, fname):
         """
         Exports relationships into 3 columns table.
@@ -318,27 +236,16 @@ class Bel(object):
         fname : str
             Filename.
         """
-        
         with open(fname, 'w') as fp:
-            
-            _ = fp.write('Subject\tPredicate\tObject\n')
-            
-            _ = fp.write(
-                '\n'.join(
-                    '\t'.join(rel[:3])
-                    for rel in self.relationships
-                )
-            )
-    
-    
-    def export_bel(self, fname):
+            print('Subject\tPredicate\tObject', file=fp)
+            for u, v, d in self.bel_graph.edges(data=True):
+                print('\t'.join((u.name, d[pc.RELATION, v.name])), file=fp)
+
+    def export_bel(self, fname, **kwargs):
         """
         Exports the BEL model into file.
         
         fname : str
             Filename.
         """
-        
-        with open(fname, 'w') as fp:
-            
-            pybel.to_bel(self.bel, file = fp)
+        pybel.to_bel_path(self.bel_graph, fname, **kwargs)

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -98,6 +98,11 @@ class Bel(BELManagerMixin):
         if init:
             self.main()
 
+    @property
+    def initialized(self) -> bool:
+        """Check if the BEL graph has been initialized."""
+        return 0 < self.bel_graph.number_of_nodes()
+
     def reload(self):
         modname = self.__class__.__module__
         mod = __import__(modname, fromlist=[modname.split('.')[0]])
@@ -248,6 +253,8 @@ class Bel(BELManagerMixin):
 
     def to_bel(self) -> pybel.BELGraph:
         """Export the BEL graph."""
+        if not self.initialized:
+            self.main()
         return self.bel_graph
 
     def to_bel_path(self, path: str, **kwargs):

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -272,19 +272,19 @@ class Bel(BELManagerMixin):
         @click.group()
         @click.option('--dataset')
         @click.pass_context
-        def main(ctx: click.Context, dataset: str):
+        def _main(ctx: click.Context, dataset: str):
             """Bio2BEL OmniPath CLI."""
             resource = get_resource(dataset)
             ctx.obj = cls(resource=resource)
 
-        @main.group()
+        @_main.group()
         def bel():
             """BEL utilities."""
 
         cls._cli_add_to_bel(bel)
         cls._cli_add_upload_bel(bel)
 
-        return main
+        return _main
 
 
 main = Bel.get_cli()

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -47,6 +47,7 @@ except ModuleNotFoundError:
     pybel = None
 
 import pybel.constants as pc
+import pybel.dsl
 from bio2bel.manager.bel_manager import BELManagerMixin
 from bio2bel.manager.cli_manager import CliMixin
 
@@ -72,6 +73,7 @@ class Bel(BELManagerMixin, CliMixin):
     
     Examples
     --------
+    >>> import os
     >>> from pypath import main, data_formats, bel
     >>> pa = main.PyPath()
     >>> pa.init_network(data_formats.pathway)
@@ -174,9 +176,8 @@ class Bel(BELManagerMixin, CliMixin):
                 target = self._protein(directions.nodes[1])
 
                 for citation in citations:
-                    self.bel_graph.add_qualified_edge(
+                    self.bel_graph.add_association(
                         source, target,
-                        relation='association',
                         citation=citation,
                         evidence='From OmniPath',
                     )

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -2,6 +2,9 @@
 
 """Convert OmniPath components to PyBEL.
 
+This module also installs a command line interface that can either be acccessed
+via: ``python -m pypath.bel`` or directly as ``bio2bel_omnipath``.
+
 This file is part of the `pypath` python module
 
 Copyright

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -155,21 +155,21 @@ class Bel:
                         evidence='From OmniPath',
                     )
 
-        if not self._has_direction(directions):
-            # add an undirected relationship
-            # if no direction available
+            if not self._has_direction(directions):
+                # add an undirected relationship
+                # if no direction available
 
-            citations = self._references(edge, 'undirected')
-            source = self._protein(directions.nodes[0])
-            target = self._protein(directions.nodes[1])
+                citations = self._references(edge, 'undirected')
+                source = self._protein(directions.nodes[0])
+                target = self._protein(directions.nodes[1])
 
-            for citation in citations:
-                self.bel_graph.add_qualified_edge(
-                    source, target,
-                    relation='association',
-                    citation=citation,
-                    evidence='From OmniPath',
-                )
+                for citation in citations:
+                    self.bel_graph.add_qualified_edge(
+                        source, target,
+                        relation='association',
+                        citation=citation,
+                        evidence='From OmniPath',
+                    )
 
     def _references(self, edge, direction) -> Set[str]:
         by_dir = edge['refs_by_dir']

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -231,13 +231,13 @@ class Bel:
     def export_relationships(self, path: str) -> None:
         """Export relationships into 3 columns table.
         
-        fname : str
+        path : str
             Filename.
         """
         with open(path, 'w') as fp:
             print('Subject\tPredicate\tObject', file=fp)
             for u, v, d in self.bel_graph.edges(data=True):
-                print('\t'.join((u.name, d[pc.RELATION, v.name])), file=fp)
+                print('\t'.join((u.name, d[pc.RELATION], v.name)), file=fp)
 
     def to_bel_path(self, path: str, **kwargs):
         """Export the BEL model as a BEL script.

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -25,6 +25,7 @@ import itertools as itt
 import sys
 from typing import Set
 
+import click
 from tqdm import tqdm
 
 try:
@@ -52,7 +53,6 @@ except ModuleNotFoundError:
 import pybel.constants as pc
 import pybel.dsl
 from bio2bel.manager.bel_manager import BELManagerMixin
-from bio2bel.manager.cli_manager import CliMixin
 
 __all__ = [
     'Bel',
@@ -60,7 +60,7 @@ __all__ = [
 ]
 
 
-class Bel(BELManagerMixin, CliMixin):
+class Bel(BELManagerMixin):
     """Converts pypath objects to BEL format.
     
     Parameters
@@ -261,6 +261,30 @@ class Bel(BELManagerMixin, CliMixin):
     def to_bel_json(self, path: str, **kwargs):
         """Export the BEL model as a node-link JSON file."""
         pybel.to_json_path(self.to_bel(), path, **kwargs)
+
+    @classmethod
+    def get_cli(cls) -> click.Group:
+        """Get the command line interface main group."""
+
+        def get_resource(dataset):
+            raise NotImplementedError  # TODO @deeenes
+
+        @click.group()
+        @click.option('--dataset')
+        @click.pass_context
+        def main(ctx: click.Context, dataset: str):
+            """Bio2BEL OmniPath CLI."""
+            resource = get_resource(dataset)
+            ctx.obj = cls(resource=resource)
+
+        @main.group()
+        def bel():
+            """BEL utilities."""
+
+        cls._cli_add_to_bel(bel)
+        cls._cli_add_upload_bel(bel)
+
+        return main
 
 
 main = Bel.get_cli()

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -49,8 +49,11 @@ except ModuleNotFoundError:
     )
     pybel = None
 
+from bio2bel.manager.bel_manager import BELManagerMixin
+from bio2bel.manager.cli_manager import CliMixin
 
-class Bel:
+
+class Bel(BELManagerMixin, CliMixin):
     """Converts pypath objects to BEL format.
     
     Parameters
@@ -235,6 +238,10 @@ class Bel:
             print('Subject\tPredicate\tObject', file=fp)
             for u, v, d in self.bel_graph.edges(data=True):
                 print('\t'.join((u.name, d[pc.RELATION], v.name)), file=fp)
+
+    def to_bel(self) -> pybel.BELGraph:
+        """Export the BEL graph."""
+        return self.bel_graph
 
     def to_bel_path(self, path: str, **kwargs):
         """Export the BEL model as a BEL script.

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -28,6 +28,7 @@ from typing import Optional, Set, Union
 import click
 from tqdm import tqdm
 
+from pypath import data_formats
 from pypath.complex import AbstractComplexResource
 from pypath.main import PyPath
 from pypath.ptm import PtmAggregator
@@ -275,15 +276,19 @@ class Bel(BELManagerMixin):
     def get_cli(cls) -> click.Group:
         """Get the command line interface main group."""
 
-        def get_resource(dataset):
-            raise NotImplementedError  # TODO @deeenes
+        def get_resource(dataset: str):
+            if dataset == 'PyPath':
+                pa = PyPath()
+                pa.init_network(data_formats.pathway)
+                return pa
+            # TODO add more options
 
         @click.group()
-        @click.option('--dataset')
+        @click.option('-r', '--resource-name', type=click.Choice(['PyPath']), default='PyPath')
         @click.pass_context
-        def _main(ctx: click.Context, dataset: str):
+        def _main(ctx: click.Context, resource_name: str):
             """Bio2BEL OmniPath CLI."""
-            resource = get_resource(dataset)
+            resource = get_resource(resource_name)
             ctx.obj = cls(resource=resource)
 
         @_main.group()

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -94,25 +94,21 @@ class Bel:
 
     def main(self):
         """Convert the resource object to list of BEL relationships."""
-        if hasattr(self.resource, 'graph'):
-            # PyPath object
-            self.resource_to_relationships_graph()
+        if hasattr(self.resource, 'graph'):  # PyPath object
+            self.resource_to_relationships_graph(self.resource.graph)
 
-        elif hasattr(self.resource, 'enz_sub'):
-            # PtmAggregator object
-            self.resource_to_relationships_enzyme_substrate()
+        elif hasattr(self.resource, 'enz_sub'):  # PtmAggregator object
+            self.resource_to_relationships_enzyme_substrate(self.resource.enz_sub)
 
-        elif hasattr(self.resource, 'complexes'):
-            # ComplexAggregator object
-            self.resource_to_relationships_complex()
+        elif hasattr(self.resource, 'complexes'):  # ComplexAggregator object
+            self.resource_to_relationships_complexes(self.resource.complexes)
 
-        elif hasattr(self.resource, 'network'):
-            # NetworkResource object
-            self.resource_to_relationships_network()
+        elif hasattr(self.resource, 'network'):  # NetworkResource object
+            self.resource_to_relationships_network(self.resource.network)
 
-    def resource_to_relationships_graph(self):
+    def resource_to_relationships_graph(self, graph):
         """Convert a PyPath igraph object into list of BEL relationships."""
-        for edge in self.resource.graph.es:
+        for edge in graph.es:
             directions = edge['dirs']
 
             for direction in (directions.straight, directions.reverse):
@@ -212,13 +208,13 @@ class Bel:
     def _protein(identifier, id_type='uniprot') -> Protein:
         return Protein(namespace=id_type.upper(), name=identifier)
 
-    def resource_to_relationships_enzyme_substrate(self):
+    def resource_to_relationships_enzyme_substrate(self, enz_sub):
         pass
 
-    def resource_to_relationships_complex(self):
+    def resource_to_relationships_complexes(self, complexes):
         raise NotImplementedError
 
-    def resource_to_relationships_network(self):
+    def resource_to_relationships_network(self, network):
         raise NotImplementedError
 
     def export_relationships(self, fname):

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -255,13 +255,7 @@ class Bel(BELManagerMixin, CliMixin):
         """Export the BEL model as a node-link JSON file."""
         pybel.to_json_path(self.bel_graph, path, **kwargs)
 
+main = Bel.get_cli()
 
 if __name__ == '__main__':
-    from pypath import main, data_formats
-    import os
-
-    pa = main.PyPath()
-    pa.init_network(data_formats.pathway)
-    be = Bel(resource=pa)
-    be.main()
-    be.to_bel_json(os.path.join(os.path.expanduser('~'), 'Desktop', 'omnipath.bel.json'))
+    main()

--- a/src/pypath/bel.py
+++ b/src/pypath/bel.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""Convert OmniPath components to PyBEL."""
+
 #
 #  This file is part of the `pypath` python module
 #
@@ -19,7 +21,6 @@
 #
 
 
-import collections
 import imp
 import itertools as itt
 import sys
@@ -29,7 +30,6 @@ import pybel.constants as pc
 from pybel.dsl import Protein
 
 try:
-
     import pybel
 
     if hasattr(pybel, 'ob'):
@@ -45,23 +45,15 @@ try:
         pybel = None
 
 except ModuleNotFoundError:
-
     sys.stdout.write(
         'pypath.bel: module `pybel` not available.\n'
         'You won\'t be able to read or write BEL models.\n'
     )
-
     pybel = None
 
-Relationship = collections.namedtuple(
-    'Relationship',
-    ('subject', 'predicate', 'object', 'references'),
-)
 
-
-class Bel(object):
-    """
-    Converts pypath objects to BEL format.
+class Bel:
+    """Converts pypath objects to BEL format.
     
     Parameters
     ----------
@@ -88,8 +80,8 @@ class Bel(object):
             self,
             resource,
             only_sources=None,
-    ):
-        self.bel_graph: pybel.BELGraph = pybel.BELGraph()
+    ) -> None:
+        self.bel_graph = pybel.BELGraph()
         self.resource = resource
         self.only_sources = only_sources
 

--- a/src/pypath/plot.py
+++ b/src/pypath/plot.py
@@ -37,7 +37,6 @@ import numpy as np
 from numpy.random import randn
 import matplotlib as mpl
 import scipy.cluster.hierarchy as hc
-import cairo
 import igraph
 
 try:
@@ -2546,6 +2545,7 @@ class SimilarityGraph(object):
             v2['name'] = ''
 
     def init_pdf(self):
+        import cairo
         self.surface = cairo.PDFSurface(self.fname, self.width, self.height)
         self.bbox = igraph.drawing.utils.BoundingBox(self.margin, self.margin,
                                                      self.width - self.margin,


### PR DESCRIPTION
I've switched some of the generation of BEL content to use PyBEL's internal DSL - this means that you don't have to generate BEL strings then re-parse them - it's now just generating pre-parsed BEL. 

Also, rather than storing relationships, I've added them directly to the instance of the BELGraph class. You can operate on that and generate the same summaries as before, as well as access the entire library of graph manipulations available through the class and PyBEL