### PR TITLE
`inputs`: added new datasets and/or attributes to some modules + url version updates

### DIFF
--- a/pypath/inputs/biogrid.py
+++ b/pypath/inputs/biogrid.py
@@ -29,7 +29,7 @@ import pypath.share.curl as curl
 
 def biogrid_interactions(organism = 9606, htp_limit = 1, ltp = True):
     """
-    Downloads and processes BioGRID interactions.
+    Downloads and processes Physical multi-validated BioGRID interactions.
     Keeps only the "low throughput" interactions.
     Returns list of interactions.
 
@@ -52,7 +52,7 @@ def biogrid_interactions(organism = 9606, htp_limit = 1, ltp = True):
     organism = str(organism)
     interactions = []
     refc = []
-    url = urls.urls['biogrid']['url']
+    url = urls.urls['biogrid']['mv']
     c = curl.Curl(url, silent = False, large = True)
     f = next(iter(c.result.values()))
     nul = f.readline()
@@ -78,6 +78,88 @@ def biogrid_interactions(organism = 9606, htp_limit = 1, ltp = True):
                         partner_a = l[7],
                         partner_b = l[8],
                         pmid = l[14]
+                    )
+                )
+                refc.append(l[14])
+
+    refc = collections.Counter(refc)
+
+    if htp_limit is not None:
+
+        interactions = [i for i in interactions if refc[i[2]] <= htp_limit]
+
+    return interactions
+
+
+def biogrid_all_interactions(organism = 9606, htp_limit = 1, ltp = True):
+
+    """
+    Downloads and processes all BioGRID interactions.
+    Keeps only the "low throughput" interactions.
+    Returns list of interactions.
+
+    @organism : int
+        NCBI Taxonomy ID of organism.
+    @htp_limit : int
+        Exclude interactions only from references
+        cited at more than this number of interactions.
+    """
+
+
+    BiogridInteraction = collections.namedtuple(
+        'BiogridInteraction',
+        (
+            'partner_a',
+            'partner_b',
+            'pmid',
+            'experimental_system',
+            'experimental_system_type',
+            'throughput',
+            'htp_score',
+            'multi_validated',
+        ),
+    )
+
+    organism = str(organism)
+    interactions = []
+    refc = []
+    mv_dict=collections.defaultdict(list)
+    for i in biogrid_interactions(organism, htp_limit, ltp):
+        mv_dict[i.partner_a].append(i.partner_b)
+    url = urls.urls['biogrid']['all']
+    c = curl.Curl(url, silent = False, large = True)
+    f = next(iter(c.result.values()))
+    nul = f.readline()
+
+    for l in f:
+
+        l = l.split('\t')
+
+        if len(l) > 17:
+
+            if (
+                (
+                    l[17].startswith('Low') or
+                    not ltp
+                ) and (
+                    l[15] == organism and
+                    l[16] == organism
+                )
+            ):
+                if l[8] in mv_dict[l[7]] or l[7] in mv_dict[l[8]]:
+                    mv="+"
+                else:
+                    mv=""
+                interactions.append(
+                    BiogridInteraction(
+                        partner_a = l[7],
+                        partner_b = l[8],
+                        pmid = l[14],
+                        experimental_system= l[11],
+                        experimental_system_type= l[12],
+                        throughput= l[17],
+                        htp_score= l[18],
+                        multi_validated= mv
                     )
                 )
                 refc.append(l[14])

--- a/pypath/inputs/intact.py
+++ b/pypath/inputs/intact.py
@@ -56,6 +56,7 @@ def intact_interactions(
             'id_type_b',
             'pubmeds',
             'methods',
+            'interaction_types',
             'mi_score',
             'isoform_a',
             'isoform_b',
@@ -186,6 +187,11 @@ def intact_interactions(
                 for met in  l[6].split('|')
             )
 
+            interaction_types= set(
+                int_type.split('(')[1].strip(')"')
+                for int_type in  l[11].split('|')
+            )
+
             results.append(
                 IntactInteraction(
                     id_a = id_a,
@@ -194,6 +200,7 @@ def intact_interactions(
                     id_type_b = id_type_b,
                     pubmeds = pubmeds,
                     methods = methods,
+                    interaction_types= interaction_types,
                     mi_score = sc,
                     isoform_a = isoform_a,
                     isoform_b = isoform_b,

--- a/pypath/inputs/string.py
+++ b/pypath/inputs/string.py
@@ -89,3 +89,154 @@ def string_effects(
                 )
 
     return effects
+
+
+def string_links(
+    ncbi_tax_id = 9606,
+    score_threshold = 'highest_confidence',
+    physical_interaction_score= True,
+):
+
+    """
+    Downloads protein network data, including subscores per channel.  
+    The output contains both functional and physical protein associations.
+    The combined physical interaction score is defined 
+    between the proteins for which we have evidence of their binding or forming a physical complex.
+    
+    :param int,str score_threshold: 
+        minimum required interaction score. user can use pre-defined confidence limits or can define a custom value.
+    """
+
+    confidence= {'highest_confidence':900,
+        'high_confidence':700,
+        'medium_confidence':400,
+        'low_confidence':0.150}
+
+    StringLinks = collections.namedtuple(
+        'StringLinks',
+        (
+            'protein_a',
+            'protein_b',
+            'neighborhood_score',
+            'fusion',
+            'cooccurence',
+            'coexpression',
+            'experimental',
+            'database',
+            'textmining',
+            'combined_score',
+            'physical_combined_score',
+        ),
+    )
+    if physical_interaction_score:
+        phy_links=string_physical_links(ncbi_tax_id, score_threshold=0)
+        phy_links_dict={}
+        for i in phy_links:
+            phy_links_dict[(i.protein_a,i.protein_b)] = i.combined_score
+
+    url = urls.urls['string']['links'] % ncbi_tax_id
+    c = curl.Curl(url, silent = False, large = True)
+    _ = next(c.result)
+
+    
+    if score_threshold not in confidence:
+        confidence[score_threshold]= score_threshold
+
+    for l in c.result:
+        l = l.strip().split(' ')
+        prot_a_id=l[0].split('.')[1]
+        prot_b_id=l[1].split('.')[1]
+        if int(l[9]) < confidence[score_threshold]:
+            continue
+
+        if physical_interaction_score and (prot_a_id,prot_b_id) in phy_links_dict:
+            phy_score = phy_links_dict[(prot_a_id,prot_b_id)]
+        else:
+            phy_score=''
+
+
+        yield StringLinks(
+            protein_a= prot_a_id,
+            protein_b= prot_b_id,
+            neighborhood_score= int(l[2]),
+            fusion= int(l[3]),
+            cooccurence= int(l[4]),
+            coexpression= int(l[5]),
+            experimental= int(l[6]),
+            database= int(l[7]),
+            textmining= int(l[8]),
+            combined_score= int(l[9]),
+            physical_combined_score=phy_score,
+        )
+
+
+def string_physical_links(
+    ncbi_tax_id = 9606,
+    score_threshold = 'highest_confidence'
+):
+
+    """
+    Downloads protein physical subnetwork data, including subscores per channel.
+    The interactions indicate that the proteins are part of a physical complex.
+    
+    :param int,str score_threshold: 
+        minimum required interaction score. user can use pre-defined confidence limits or can define a custom value.
+    """
+
+    confidence= {'highest_confidence':900,
+        'high_confidence':700,
+        'medium_confidence':400,
+        'low_confidence':0.150}
+
+    StringLinks = collections.namedtuple(
+        'StringLinks',
+        (
+            'protein_a',
+            'protein_b',
+            'experimental',
+            'database',
+            'textmining',
+            'combined_score'
+        ),
+    )
+
+    links=[]
+
+
+    url = urls.urls['string']['physical_links'] % ncbi_tax_id
+    c = curl.Curl(url, silent = False, large = True)
+    _ = next(c.result)
+    
+    if score_threshold in confidence:
+        for l in c.result:
+            l = l.strip().split(' ')
+            if int(l[5]) >= confidence[score_threshold]:
+                links.append(
+                    StringLinks(
+                        protein_a= l[0].split('.')[1],
+                        protein_b= l[1].split('.')[1],
+                        experimental= int(l[2]),
+                        database= int(l[3]),
+                        textmining= int(l[4]),
+                        combined_score= int(l[5])
+                        )
+                    )
+
+    else:
+        confidence["custom"]= score_threshold
+        for l in c.result:
+            l = l.strip().split(' ')
+            if int(l[5]) >= confidence["custom"]:
+                links.append(
+                    StringLinks(
+                        protein_a= l[0].split('.')[1],
+                        protein_b= l[1].split('.')[1],
+                        experimental= int(l[2]),
+                        database= int(l[3]),
+                        textmining= int(l[4]),
+                        combined_score= int(l[5])
+                        )
+                    )
+    return links
+
+

--- a/pypath/resources/urls.py
+++ b/pypath/resources/urls.py
@@ -791,9 +791,10 @@ urls = {
     },
     'biogrid': {
         'label': 'BioGRID version 2 tab format',
-        'url':
-        'http://thebiogrid.org/downloads/archives/Latest%20Release/'\
-            'BIOGRID-MV-Physical-LATEST.tab2.zip'
+        'mv': 'http://thebiogrid.org/downloads/archives/Latest%20Release/'\
+            'BIOGRID-MV-Physical-LATEST.tab2.zip',
+        'all': 'http://thebiogrid.org/downloads/archives/Latest%20Release/'\
+            'BIOGRID-ALL-LATEST.tab2.zip'
     },
     'wang': {
         'label':
@@ -930,8 +931,10 @@ urls = {
         'label': 'STRING',
         'actions': 'https://stringdb-static.org/download/'
             'protein.actions.v11.0/%u.protein.actions.v11.0.txt.gz',
-        'links': 'http://string-db.org/download/protein.links.detailed.v10/%u'
-        '.protein.links.detailed.v10.txt.gz'
+        'links': 'https://stringdb-static.org/download/protein.links.detailed.v11.5/%u'
+            '.protein.links.detailed.v11.5.txt.gz',
+        'physical_links': 'https://stringdb-static.org/download/protein.physical.links.detailed.v11.5/%u'
+            '.protein.physical.links.detailed.v11.5.txt.gz'
     },
     'wikipw': {
         'label': 'WikiPathways human biopax',
@@ -1090,7 +1093,9 @@ urls = {
     'stitch': {
         'label': 'The STITCH small molecule-protein interaction database',
         'actions': 'http://stitch.embl.de/download/actions.v5.0/'\
-            '9606.actions.v5.0.tsv.gz'
+            '9606.actions.v5.0.tsv.gz',
+        'links': 'http://stitch.embl.de/download/protein_chemical.links.detailed.v5.0/%u'\
+            '.protein_chemical.links.detailed.v5.0.tsv.gz'
     },
     'cspa': {
         'label': 'Cell Surface Protein Atlas',


### PR DESCRIPTION
- Added ALL-LATEST.tab2.zip dataset to `inputs.biogrid`
- Added `interaction_type` attribute to `inputs.intact`
- Added interaction data with detailed subscores for both `inputs.string` and `inputs.stitch`
- Added physical interaction subnetwork data to `inputs.string` (apparently actions dataset is no longer supported for the latest version. they use physical.links datasets instead.)
- Changed/updated related urls 