### PR TITLE
Update uniprot + cellphonedb URLs

### DIFF
--- a/pypath/resources/urls.py
+++ b/pypath/resources/urls.py
@@ -30,7 +30,7 @@ import pypath.share.settings as settings
 urls = {
     'uniprot_pdb': {
         'label': 'Getting PDB IDs of 3D structures for UniProtIDs',
-        'url': 'http://www.uniprot.org/docs/pdbtosp.txt'
+        'url': 'https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/docs/pdbtosp.txt'
     },
     'uniprot_basic': {
         'label': 'URL for UniProt queries',
@@ -48,7 +48,7 @@ urls = {
             'knowledgebase/complete/docs/speindex.txt',
         'taxids': 'https://www.uniprot.org/taxonomy/?query='
             '*&format=tab&force=true&columns=id&compress=yes',
-        'speclist': 'https://www.uniprot.org/docs/speclist.txt',
+        'speclist': 'https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/docs/speclist.txt',
     },
     'corum': {
         'label':

--- a/pypath/resources/urls.py
+++ b/pypath/resources/urls.py
@@ -1089,16 +1089,15 @@ urls = {
     },
     'cellphonedb_git': {
         'label': 'Intercellular communication database from Teichmann lab',
-        'proteins': 'https://raw.githubusercontent.com/Teichlab/'\
-            'cellphonedb/master/cellphonedb/src/core/data/protein_input.csv',
-        'complexes': 'https://raw.githubusercontent.com/Teichlab/'\
-            'cellphonedb/master/cellphonedb/src/core/data/complex_input.csv',
-        'interactions': 'https://raw.githubusercontent.com/Teichlab/'\
-            'cellphonedb/master/cellphonedb/src/core/data/'\
-            'interaction_input.csv',
-        'curated': 'https://raw.githubusercontent.com/Teichlab/'\
-            'cellphonedb-data/data/sources/interaction_curated.csv',
-        'negative': 'https://raw.githubusercontent.com/Teichlab/'\
+        'proteins': 'https://raw.githubusercontent.com/ventolab/'\
+            'cellphonedb-data/master/data/protein_input.csv',
+        'complexes': 'https://raw.githubusercontent.com/ventolab/'\
+            'cellphonedb-data/master/data/complex_input.csv',
+        'interactions': 'https://raw.githubusercontent.com/ventolab/'\
+            'cellphonedb-data/master/data/interaction_input.csv',
+        'curated': 'https://raw.githubusercontent.com/ventolab/'\
+            'cellphonedb-data/master/data/sources/interaction_curated.csv',
+        'negative': 'https://raw.githubusercontent.com/ventolab/'\
             'cellphonedb-data/master/data/sources/excluded_interaction.csv',
     },
     'stitch': {


### PR DESCRIPTION
These changes were how I figured out how to fix https://github.com/saezlab/pypath/issues/189 temporarily by:

1) Substitute links to `pdbtosp.txt` and `speclist.txt` to prevent uniprot from failing.
2) Update `cellphonedb_git` links to point to cellphoneDB v4.0.0 database as the URLs were changed. This adds ~800 new interactions versus v2.0.0.