### PR TITLE
Fixed error retrieving boolean annotations

### DIFF
--- a/pypath/inputs/cellphonedb.py
+++ b/pypath/inputs/cellphonedb.py
@@ -90,7 +90,7 @@ def _cellphonedb_annotations(url, name_method):
 
     def get_bool(rec, attr):
 
-        return attr in rec and rec[attr] == 'True'
+        return attr in rec and rec[attr].upper() == 'TRUE'
 
     def get_desc(rec, attr):
 
@@ -99,7 +99,7 @@ def _cellphonedb_annotations(url, name_method):
         value = (
             ''
                 if (
-                    attr in rec and rec[attr] == 'False' or
+                    attr in rec and rec[attr].upper() == 'FALSE' or
                     attr not in rec and not rec[desc]
                 ) else
             rec[desc]


### PR DESCRIPTION
Fixed an error when processing boolean annotations that caused everything to be False. This was making some methods to give unexpected results e.g. to retrieve no ligand-receptor interactions

For some reason the attribute fields were all uppercase (e.g. `"TRUE"`), therefore `rec[attr] == 'True'` was returning `False` when it was actually `True`. Now regardless of the case (`"True"`, `"TRUE"`, `"true"`, `"TrUe"`, etc.), returns `True`

Similar thing applied in the check below for `"False"`.