### PR TITLE
fix for issue #310: expasy_enzyme_classes silently drops enzyme classes with non alphanumeric chars in description

### DIFF
--- a/pypath/inputs/expasy.py
+++ b/pypath/inputs/expasy.py
@@ -56,7 +56,7 @@ def expasy_enzyme_classes(
         r'(?:(\d+))?-?\.\s*'
         r'(?:(\d+))?-?\.\s*'
         r'-?\s+'
-        r'([-\w\(\)\s\+]+)\.$'
+        r'(.+)\.$'
     )
 
     result = []


### PR DESCRIPTION
fixed by relaxing the regexp